### PR TITLE
initial import from CF

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
 
 build:
   number: 0
-  skip: true  # [py2k]
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -22,6 +21,8 @@ requirements:
     - cython
     - numpy
     - pip
+    - setuptools
+    - wheel
     - python
   run:
     - cython

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,8 @@ about:
   summary: Creation and manipulation of parameter configuration spaces for automated algorithm configuration and hyperparameter tuning.
   license: BSD-3-Clause
   license_file: LICENSE
+  dev_url: https://github.com/automl/ConfigSpace
+  doc_url: https://automl.github.io/ConfigSpace/master/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,6 +42,7 @@ test:
 about:
   home: https://github.com/automl/ConfigSpace
   summary: Creation and manipulation of parameter configuration spaces for automated algorithm configuration and hyperparameter tuning.
+  description: A simple python module to manage configuration spaces for algorithm configuration and hyperparameter optimization tasks.
   license: BSD-3-Clause
   license_file: LICENSE
   dev_url: https://github.com/automl/ConfigSpace


### PR DESCRIPTION
Needed for autogluon https://anaconda.atlassian.net/browse/DSNC-3821

Summary: Creation and manipulation of parameter configuration spaces for automated algorithm configuration and hyperparameter tuning.

* [x] upstream repo https://github.com/automl/ConfigSpace
* [x] go through [changelog](https://github.com/automl/ConfigSpace/blob/master/changelog.md) - 0.4.20 available but autogluon pinned at 0.4.19
* [x] dev_url, doc_url valid
* [x] check license is accurate
* [x] setuptools/wheel/pip/pip check included
* [x] compare pinned versions from upstream