### PR TITLE
[PKG-4976] 0.4.21

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,4 +54,5 @@ extra:
   recipe-maintainers:
     - hadim
   skip-lints:
-    python_build_tool_in_run
+    - python_build_tool_in_run
+    - cython_must_be_in_host

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ConfigSpace" %}
-{% set version = "0.4.19" %}
+{% set version = "0.4.21" %}
 
 
 package:
@@ -8,11 +8,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/ConfigSpace-{{ version }}.tar.gz
-  sha256: f7d35c0d7155e1e757c8a3797750098cc12ab77e447c38c8da07e74b6adb11f3
+  sha256: 09c5ee343f2850865609cc91f2ab27da0a6182f7f196354f9550f6da578ea827
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv --no-deps
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   build:
@@ -29,6 +29,7 @@ requirements:
     - pyparsing
     - python
     - {{ pin_compatible('numpy') }}
+    - scipy
 
 test:
   imports:
@@ -44,6 +45,7 @@ about:
   summary: Creation and manipulation of parameter configuration spaces for automated algorithm configuration and hyperparameter tuning.
   description: A simple python module to manage configuration spaces for algorithm configuration and hyperparameter optimization tasks.
   license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE
   dev_url: https://github.com/automl/ConfigSpace
   doc_url: https://automl.github.io/ConfigSpace/master/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,3 +53,5 @@ about:
 extra:
   recipe-maintainers:
     - hadim
+  skip-lints:
+    python_build_tool_in_run

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,7 @@ about:
   license_family: BSD
   license_file: LICENSE
   dev_url: https://github.com/automl/ConfigSpace
-  doc_url: https://automl.github.io/ConfigSpace/master/
+  doc_url: https://automl.github.io/ConfigSpace/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
configspace 0.4.21

**Destination channel:** defaults

### Links

- [PKG-4976] 
- [Upstream repository](https://github.com/automl/ConfigSpace)
- [Upstream changelog/diff](https://github.com/automl/ConfigSpace/blob/v0.4.21/changelog.md)

### Explanation of changes:

- Most of the upstream tests are failing due to issues related to type checking with `cython`
  - These issues are being fixed with the upcoming 1.0 release. See related upstream PR here: https://github.com/automl/ConfigSpace/pull/346
- Building an older version (0.4.21) for compatibility with [auto-sklearn](https://github.com/automl/auto-sklearn/blob/b7ff90c49c50d5b764713185edf62356415fd515/requirements.txt#L18)


[PKG-4976]: https://anaconda.atlassian.net/browse/PKG-4976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ