### PR TITLE
configspace 1.2.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "ConfigSpace" %}
-{% set version = "0.4.21" %}
-
+{% set version = "1.2.1" %}
 
 package:
   name: {{ name|lower }}
@@ -10,46 +9,39 @@ source:
   # Use upstream archive tarball for tests -- pypi does not include
   # the subdirs of test/
   url: https://github.com/automl/ConfigSpace/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 227426b9bd48d9379d6104ab58f3b60edd586b8bee003ddb3ee2a59fcdfd0459
+  sha256: 7b2d129ce6d839d2bc75e77f6656915a633931a98dfb3c0117f4145ae5dda422
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
-  build:
-    - {{ compiler('c') }}
   host:
-    # cython<3 would be valid for this release of ConfigSpace and
-    # prevents various cast problems in the tests
-    - cython <3
-    - numpy {{ numpy }}
+    - python
     - pip
     - setuptools
     - wheel
-    - python
   run:
-    # keep runtime use of cython compatible for the reasons above
-    - cython <3
-    - pyparsing
     - python
-    - {{ pin_compatible('numpy') }}
+    - more-itertools
+    - numpy
+    - pyparsing
     - scipy
+    - typing_extensions
 
 test:
   source_files:
     - test
   imports:
     - ConfigSpace
-    - ConfigSpace.nx
   requires:
     - pip
-    - pytest
+    - pytest >=7
   commands:
     - pip check
-    - pytest -v test                              # [not (linux and x86_64)]
-    # 99 != 100 in the bowels of the computation
-    - pytest -v test -k 'not test_generate_grid'  # [linux and x86_64]
+    # Ignore test_functional.py because of ModuleNotFoundError: No module named 'pytest_cases',
+    # pytest_cases isn't available on the main channel
+    - pytest -v test --ignore="test/test_functional.py"
 
 about:
   home: https://github.com/automl/ConfigSpace

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,4 +58,3 @@ extra:
     - hadim
   skip-lints:
     - python_build_tool_in_run
-    - cython_must_be_in_host


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7413](https://anaconda.atlassian.net/browse/PKG-7413)
- [Upstream repo](https://github.com/automl/ConfigSpace/tree/v1.2.1)
- release-diff: https://github.com/automl/ConfigSpace/compare/v0.4.21...v1.2.1
- changelog: https://github.com/automl/ConfigSpace/blob/main/changelog.md
- license: https://github.com/automl/ConfigSpace/blob/main/LICENSE
- requirements-tagged:
  - https://github.com/automl/ConfigSpace/blob/v1.2.1/pyproject.toml


### Explanation of changes:

- Reset the build number to 0
- Remove requirements.build.
- Update host and run dependencies
- Remove ConfigSpace.nx from test.imports
- Ignore test/test_functional.py because `pytest_cases` isn't available on the main channel

[PKG-7413]: https://anaconda.atlassian.net/browse/PKG-7413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ