### PR TITLE
configspace 1.2.2 

### DIFF
--- a/recipe/fix_version.patch
+++ b/recipe/fix_version.patch
@@ -1,0 +1,12 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index a2f9e80..5479a99 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,6 +1,6 @@
+ [project]
+ name = "ConfigSpace"
+-version = "1.2.1"
++version = "1.2.2"
+ description = """\
+     Creation and manipulation of parameter configuration spaces for \
+     automated algorithm configuration and hyperparameter tuning. \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,17 @@
-{% set name = "ConfigSpace" %}
+{% set name = "configspace" %}
 {% set version = "1.2.2" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  # Use upstream archive tarball for tests -- pypi does not include
-  # the subdirs of test/
+  # Use upstream archive tarball because the PyPI sdist omits test subdirectories.
   url: https://github.com/automl/ConfigSpace/archive/refs/tags/v{{ version }}.tar.gz
   sha256: aaaa15b3862d554d2164964248a2d17582faa23867c343f206fa21ad1c376a9b
+  patches:
+    # Fix incorrect package metadata in the upstream v1.2.2 tag.
+    - fix_version.patch
 
 build:
   number: 0
@@ -57,5 +59,3 @@ about:
 extra:
   recipe-maintainers:
     - hadim
-  skip-lints:
-    - python_build_tool_in_run

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ConfigSpace" %}
-{% set version = "1.2.1" %}
+{% set version = "1.2.2" %}
 
 package:
   name: {{ name|lower }}
@@ -9,11 +9,12 @@ source:
   # Use upstream archive tarball for tests -- pypi does not include
   # the subdirs of test/
   url: https://github.com/automl/ConfigSpace/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 7b2d129ce6d839d2bc75e77f6656915a633931a98dfb3c0117f4145ae5dda422
+  sha256: aaaa15b3862d554d2164964248a2d17582faa23867c343f206fa21ad1c376a9b
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: true  # [py<39]
 
 requirements:
   host:


### PR DESCRIPTION
configspace 1.2.2 

**Destination channel:** Defaults

### Links

- [PKG-16546]
- dev_url:        https://github.com/automl/ConfigSpace/tree/v1.2.2
- conda_forge:    https://github.com/conda-forge/configspace-feedstock
- pypi:           https://pypi.org/project/configspace/1.2.2
- pypi inspector: https://inspector.pypi.io/project/configspace/1.2.2

### Explanation of changes:

- new version number


[PKG-16546]: https://anaconda.atlassian.net/browse/PKG-16546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ